### PR TITLE
chore: Format bundle.proto

### DIFF
--- a/protos/cerbos/cloud/bundle/v1/bundle.proto
+++ b/protos/cerbos/cloud/bundle/v1/bundle.proto
@@ -20,7 +20,9 @@ message BundleInfo {
       unique: true,
       min_items: 1,
       items {
-        string {min_len: 1}
+        string {
+          min_len: 1
+        }
       }
     }];
   }


### PR DESCRIPTION
When I run `make generate` in spitfire, I get a diff on this file.