### PR TITLE
chore: Disable Connect RPC metrics

### DIFF
--- a/bundle/client.go
+++ b/bundle/client.go
@@ -127,7 +127,7 @@ func NewClient(conf ClientConf) (*Client, error) {
 	options := []connect.ClientOption{
 		connect.WithCompressMinBytes(1024),
 		connect.WithInterceptors(
-			otelconnect.NewInterceptor(),
+			otelconnect.NewInterceptor(otelconnect.WithoutMetrics()),
 			newUserAgentInterceptor(),
 		),
 	}


### PR DESCRIPTION
The metrics produced by Connect interceptor clash with the metrics from
the gRPC and cause the metrics export to fail completely. This appears
to be caused by not having the same description for the `rpc_client_*`
metrics.

```
collected metric rpc_client_duration_milliseconds label:{name:"rpc_grpc_status_code"  value:"0"}  label:{name:"rpc_method"  value:"CheckResourceSet"}  label:{name:"rpc_service"  value:"cerbos.svc.v1.CerbosService"}  label:{name:"rpc_system"  value:"grpc"}  histogram:{sample_count:3  sample_sum:25.514295999999998  bucket:{cumulative_count:0  upper_bound:0}  bucket:{cumulative_count:2  upper_bound:5}  bucket:{cumulative_count:2  upper_bound:10}  bucket:{cumulative_count:3  upper_bound:25}  bucket:{cumulative_count:3  upper_bound:50}  bucket:{cumulative_count:3  upper_bound:75}  bucket:{cumulative_count:3  upper_bound:100}  bucket:{cumulative_count:3  upper_bound:250}  bucket:{cumulative_count:3  upper_bound:500}  bucket:{cumulative_count:3  upper_bound:750}  bucket:{cumulative_count:3  upper_bound:1000}  bucket:{cumulative_count:3  upper_bound:2500}  bucket:{cumulative_count:3  upper_bound:5000}  bucket:{cumulative_count:3  upper_bound:7500}  bucket:{cumulative_count:3  upper_bound:10000}} has help "Measures the duration of inbound RPC." but should have ""
```

Signed-off-by: Charith Ellawala <charith@cerbos.dev>
