### PR TITLE
enhancement: Make private key optional

### DIFF
--- a/credentials/credentials_test.go
+++ b/credentials/credentials_test.go
@@ -20,21 +20,40 @@ var encrypted []byte
 func TestCredentials(t *testing.T) {
 	clientID := "clientid"
 	clientSecret := "clientsecret"
-	privateKey := "CERBOS-1MKYX97DHPT3B-L05ALANNYUXY7HEMFXUNQRLS47D8G8D9ZYUMEDPE4X2382Q2WMSSXY2G2A"
 
-	c, err := credentials.New(clientID, clientSecret, privateKey)
-	require.NoError(t, err, "Failed to create credentials")
-	require.Equal(t, clientID, c.ClientID, "Client ID mismatch")
-	require.Equal(t, clientSecret, c.ClientSecret, "Client secret mismatch")
-	require.Equal(t, "MKYX97DHPT3B", c.WorkspaceID, "Workspace ID mismatch")
+	t.Run("with private key", func(t *testing.T) {
+		privateKey := "CERBOS-1MKYX97DHPT3B-L05ALANNYUXY7HEMFXUNQRLS47D8G8D9ZYUMEDPE4X2382Q2WMSSXY2G2A"
 
-	have, err := c.Decrypt(bytes.NewReader(encrypted))
-	require.NoError(t, err, "Failed to decrypt")
+		c, err := credentials.New(clientID, clientSecret, privateKey)
+		require.NoError(t, err, "Failed to create credentials")
+		require.Equal(t, clientID, c.ClientID, "Client ID mismatch")
+		require.Equal(t, clientSecret, c.ClientSecret, "Client secret mismatch")
+		require.Equal(t, "MKYX97DHPT3B", c.WorkspaceID, "Workspace ID mismatch")
 
-	haveDecrypted := new(bytes.Buffer)
-	_, err = haveDecrypted.ReadFrom(have)
-	require.NoError(t, err)
-	require.Equal(t, "cerbos", haveDecrypted.String())
+		have, err := c.Decrypt(bytes.NewReader(encrypted))
+		require.NoError(t, err, "Failed to decrypt")
 
-	require.Equal(t, "d27f6dfbae5e84c7557e7e013e0bab6e81ada2b4a817689684652548448b6267", c.HashString("cerbos"))
+		haveDecrypted := new(bytes.Buffer)
+		_, err = haveDecrypted.ReadFrom(have)
+		require.NoError(t, err)
+		require.Equal(t, "cerbos", haveDecrypted.String())
+
+		require.Equal(t, "d27f6dfbae5e84c7557e7e013e0bab6e81ada2b4a817689684652548448b6267", c.HashString("cerbos"))
+	})
+
+	t.Run("without private key", func(t *testing.T) {
+		c, err := credentials.New(clientID, clientSecret, "")
+		require.NoError(t, err, "Failed to create credentials")
+		require.Equal(t, clientID, c.ClientID, "Client ID mismatch")
+		require.Equal(t, clientSecret, c.ClientSecret, "Client secret mismatch")
+		require.Empty(t, c.WorkspaceID, "Workspace ID mismatch")
+
+		_, err = c.Decrypt(bytes.NewReader(encrypted))
+		require.ErrorIs(t, err, credentials.ErrInvalidPrivateKey)
+
+		_, err = c.Encrypt(new(bytes.Buffer))
+		require.ErrorIs(t, err, credentials.ErrInvalidPrivateKey)
+
+		require.Equal(t, "eaf69a17369b5b65a4bc95b0b5803afb64818cb9ad6d98dac67118d691b06bd4", c.HashString("cerbos"))
+	})
 }


### PR DESCRIPTION
This PR makes the private key optional in the Hub credentials config because playground bundles aren't encrypted (because they are only accessible via the API using client credentials to authenticate).