### PR TITLE
fix: Return server backoff duration from logcap client

### DIFF
--- a/logcap/client.go
+++ b/logcap/client.go
@@ -39,11 +39,7 @@ func (c *Client) Ingest(ctx context.Context, batch *logsv1.IngestBatch) (time.Du
 	}))
 	if err != nil {
 		log.Error(err, "Ingest RPC failed")
-		var d time.Duration
-		if resp != nil && resp.Msg != nil {
-			d = resp.Msg.GetBackoff().GetDuration().AsDuration()
-		}
-		return d, err
+		return 0, err
 	}
 
 	base.LogResponsePayload(log, resp.Msg)

--- a/logcap/client_test.go
+++ b/logcap/client_test.go
@@ -137,7 +137,7 @@ func TestIngest(t *testing.T) {
 				Status: &logsv1.IngestResponse_Success{},
 			}), nil).Once()
 
-		err := client.Ingest(context.Background(), batch)
+		_, err := client.Ingest(context.Background(), batch)
 		require.NoError(t, err)
 	})
 
@@ -153,7 +153,7 @@ func TestIngest(t *testing.T) {
 			IssueAccessToken(mock.Anything, mock.MatchedBy(issueAccessTokenRequest())).
 			Return(nil, connect.NewError(connect.CodeUnauthenticated, errors.New("🙅")))
 
-		err := client.Ingest(context.Background(), &logsv1.IngestBatch{})
+		_, err := client.Ingest(context.Background(), &logsv1.IngestBatch{})
 		require.Error(t, err)
 		require.ErrorIs(t, err, base.ErrAuthenticationFailed)
 	})


### PR DESCRIPTION
Precursor to correctly handling server-issued audit log ingest backoffs in the PDP.