### PR TITLE
enhancement: Configure circuit breaker with failure rate threshold

### DIFF
--- a/base/interceptors.go
+++ b/base/interceptors.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"runtime"
 	"runtime/debug"
+	"time"
 
 	"connectrpc.com/connect"
 	"github.com/failsafe-go/failsafe-go"
@@ -21,7 +22,7 @@ var circuitBreaker failsafe.Executor[connect.AnyResponse]
 func init() {
 	circuitBreaker = failsafe.NewExecutor(
 		circuitbreaker.Builder[connect.AnyResponse]().
-			WithFailureThresholdRatio(6, 10).
+			WithFailureRateThreshold(60, 5, 15*time.Second). // open circuit if >=5 requests have been made in the last 15 seconds and >=60% of them have failed
 			HandleIf(func(_ connect.AnyResponse, err error) bool {
 				if err == nil {
 					return false

--- a/base/interceptors.go
+++ b/base/interceptors.go
@@ -20,24 +20,7 @@ import (
 var circuitBreaker failsafe.Executor[connect.AnyResponse]
 
 func init() {
-	circuitBreaker = failsafe.NewExecutor(
-		circuitbreaker.Builder[connect.AnyResponse]().
-			WithFailureRateThreshold(60, 5, 15*time.Second). // open circuit if >=5 requests have been made in the last 15 seconds and >=60% of them have failed
-			HandleIf(func(_ connect.AnyResponse, err error) bool {
-				if err == nil {
-					return false
-				}
-
-				code := connect.CodeOf(err)
-				switch code {
-				case connect.CodeAborted, connect.CodeCanceled, connect.CodeDeadlineExceeded, connect.CodeFailedPrecondition:
-					return false
-				default:
-					return true
-				}
-			}).
-			Build(),
-	)
+	circuitBreaker = newCircuitBreaker()
 }
 
 type userAgentInterceptor struct {
@@ -179,4 +162,25 @@ func (cbi *circuitBreakerInterceptor) WrapStreamingClient(next connect.Streaming
 
 func (cbi *circuitBreakerInterceptor) WrapStreamingHandler(next connect.StreamingHandlerFunc) connect.StreamingHandlerFunc {
 	return next
+}
+
+func newCircuitBreaker() failsafe.Executor[connect.AnyResponse] {
+	return failsafe.NewExecutor(
+		circuitbreaker.Builder[connect.AnyResponse]().
+			WithFailureRateThreshold(60, 5, 15*time.Second). // open circuit if >=5 requests have been made in the last 15 seconds and >=60% of them have failed
+			HandleIf(func(_ connect.AnyResponse, err error) bool {
+				if err == nil {
+					return false
+				}
+
+				code := connect.CodeOf(err)
+				switch code {
+				case connect.CodeAborted, connect.CodeCanceled, connect.CodeDeadlineExceeded, connect.CodeFailedPrecondition:
+					return false
+				default:
+					return true
+				}
+			}).
+			Build(),
+	)
 }

--- a/base/test.go
+++ b/base/test.go
@@ -5,6 +5,10 @@
 
 package base
 
+func ResetCircuitBreaker() {
+	circuitBreaker = newCircuitBreaker()
+}
+
 func (c Client) BypassCircuitBreaker() {
 	c.circuitBreaker.enabled = false
 }

--- a/store/client_test.go
+++ b/store/client_test.go
@@ -392,6 +392,7 @@ func testCircuitBreaker(creds *credentials.Credentials) func(*testing.T) {
 				return cmp.Equal(c.Msg, wantReq, protocmp.Transform())
 			})).Return(nil, connect.NewError(connect.CodeCanceled, errors.New("canceled")))
 
+			base.ResetCircuitBreaker()
 			client, err := hub.StoreClient()
 			require.NoError(t, err)
 
@@ -417,6 +418,7 @@ func testCircuitBreaker(creds *credentials.Credentials) func(*testing.T) {
 				return cmp.Equal(c.Msg, wantReq, protocmp.Transform())
 			})).Return(nil, errors.New("failure is inevitable"))
 
+			base.ResetCircuitBreaker()
 			client, err := hub.StoreClient()
 			require.NoError(t, err)
 


### PR DESCRIPTION
This PR changes the circuit breaker configuration to use a failure rate threshold, so that the circuit opens if >=5 requests have been made in the last 15 seconds and >=60% of them have failed.

This means that clients that aren't making many requests are unlikely to be throttled.