### PR TITLE
enhancement: Ignore 'already exists' errors in circuit breaker

### DIFF
--- a/base/interceptors.go
+++ b/base/interceptors.go
@@ -175,7 +175,7 @@ func newCircuitBreaker() failsafe.Executor[connect.AnyResponse] {
 
 				code := connect.CodeOf(err)
 				switch code {
-				case connect.CodeAborted, connect.CodeCanceled, connect.CodeDeadlineExceeded, connect.CodeFailedPrecondition:
+				case connect.CodeAborted, connect.CodeAlreadyExists, connect.CodeCanceled, connect.CodeDeadlineExceeded, connect.CodeFailedPrecondition:
 					return false
 				default:
 					return true


### PR DESCRIPTION
We return 'already exists' for operations that don't change the store state. I don't think we should trip the circuit breaker when that happens.