### PR TITLE
Use shared Renovate config preset

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,20 +1,9 @@
 {
     "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-    "configMigration": true,
-    "commitMessageLowerCase": "never",
-    "minimumReleaseAge": "5 days",
-    "internalChecksFilter": "strict",
     "extends": [
-        "config:recommended",
+        "github>cerbos/renovate",
         "group:allNonMajor",
-        "helpers:pinGitHubActionDigests",
-        "schedule:weekly",
-        ":automergeDisabled",
-        ":combinePatchMinorReleases",
-        ":gitSignOff",
-        ":renovatePrefix",
-        ":semanticCommitTypeAll(chore)",
-        ":separateMultipleMajorReleases"
+        ":combinePatchMinorReleases"
     ],
     "packageRules": [
         {
@@ -29,14 +18,7 @@
                 "gomod"
             ],
             "groupName": "Go deps",
-            "groupSlug": "go-deps",
-            "customEnvVariables": {
-                "GOPRIVATE": "github.com/cerbos/cloud-api"
-            },
-            "postUpdateOptions": [
-                "gomodTidy",
-                "gomodUpdateImportPaths"
-            ]
+            "groupSlug": "go-deps"
         },
         {
             "matchPackageNames": [


### PR DESCRIPTION
Also fixes:

```
WARN: Found renovate config warnings
{
  "warnings": [
    {
      "topic": "Configuration Error",
      "message": "The \"customEnvVariables\" option is a global option reserved only for Renovate's global configuration and cannot be configured within a repository's config file."
    }
  ]
}
```