### PR TITLE
Enable proxy support for Hub client

### DIFF
--- a/base/client.go
+++ b/base/client.go
@@ -13,7 +13,6 @@ import (
 	"connectrpc.com/otelconnect"
 	"github.com/go-logr/logr"
 	"github.com/hashicorp/go-retryablehttp"
-	"golang.org/x/net/http2"
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/proto"
 
@@ -66,9 +65,16 @@ func (c Client) HubCredentials() *credentials.Credentials {
 }
 
 func mkHTTPClient(conf ClientConf) *http.Client {
+	protocols := new(http.Protocols)
+	protocols.SetHTTP1(true)
+	protocols.SetHTTP2(true)
+	protocols.SetUnencryptedHTTP2(true)
+
 	return &http.Client{
-		Transport: &http2.Transport{
+		Transport: &http.Transport{
 			TLSClientConfig: conf.TLS.Clone(),
+			Proxy:           http.ProxyFromEnvironment,
+			Protocols:       protocols,
 		},
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,6 @@ require (
 	github.com/zalando/go-keyring v0.2.8
 	go.uber.org/multierr v1.11.0
 	golang.org/x/crypto v0.51.0
-	golang.org/x/net v0.54.0
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260511170946-3700d4141b60
 	google.golang.org/protobuf v1.36.11
 )
@@ -67,6 +66,7 @@ require (
 	go.yaml.in/yaml/v2 v2.4.3 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/exp v0.0.0-20260508232706-74f9aab9d74a // indirect
+	golang.org/x/net v0.54.0 // indirect
 	golang.org/x/sys v0.44.0 // indirect
 	golang.org/x/text v0.37.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260511170946-3700d4141b60 // indirect


### PR DESCRIPTION
Honours `HTTP_PROXY`, `HTTPS_PROXY` and `NO_PROXY` environment
variables.

Signed-off-by: Charith Ellawala <charith@cerbos.dev>
